### PR TITLE
update tilejson whitelist

### DIFF
--- a/lib/validators/tilejson.js
+++ b/lib/validators/tilejson.js
@@ -22,4 +22,4 @@ function validateTilejson(opts, callback) {
   callback();
 }
 
-var validHosts = validateTilejson.validHosts = /tilemill\.backend$|tiles\.mapbox\.com$|^mapbox-(staff|sandbox-staff|satellite|cloudless-testing|pixelmonster)\.s3\.amazonaws\.com$/;
+var validHosts = validateTilejson.validHosts = /tilemill\.backend$|tiles\.mapbox\.com$|(^mapbox-(satellite|cloudless-testing|pixelmonster)|^tilestream-tilesets-production)\.s3\.amazonaws\.com$/;

--- a/test/expected/valid.tilejson.info.json
+++ b/test/expected/valid.tilejson.info.json
@@ -3,7 +3,7 @@
   "name": "Bright TileJSON",
   "scheme": "xyz",
   "tiles": [
-    "http://mapbox-staff.s3.amazonaws.com/datquest/new/{z}/{x}/{y}.vector.pbf"
+    "http://tilestream-tilesets-production.s3.amazonaws.com/datquest/new/{z}/{x}/{y}.vector.pbf"
   ],
   "minzoom": 0,
   "maxzoom": 6,

--- a/test/fixtures/valid.tilejson
+++ b/test/fixtures/valid.tilejson
@@ -2,7 +2,7 @@
   "tilejson": "1.0.0",
   "name": "Bright TileJSON",
   "scheme": "xyz",
-  "tiles": [ "http://mapbox-staff.s3.amazonaws.com/datquest/new/{z}/{x}/{y}.vector.pbf" ],
+  "tiles": [ "http://tilestream-tilesets-production.s3.amazonaws.com/datquest/new/{z}/{x}/{y}.vector.pbf" ],
   "minzoom": 0,
   "maxzoom": 6,
   "bounds": [ -180, -85, 180, 85 ],

--- a/test/validators.tilejson.test.js
+++ b/test/validators.tilejson.test.js
@@ -34,8 +34,7 @@ test('lib.validators.tilejson: hostnames', function(t) {
   t.ok(validHosts.test('a.tilemill.backend'), 'host is valid');
   t.ok(validHosts.test('tiles.mapbox.com'), 'host is valid');
   t.ok(validHosts.test('a.tiles.mapbox.com'), 'host is valid');
-  t.ok(validHosts.test('mapbox-staff.s3.amazonaws.com'), 'host is valid');
-  t.ok(validHosts.test('mapbox-sandbox-staff.s3.amazonaws.com'), 'host is valid');
+  t.ok(validHosts.test('tilestream-tilesets-production.s3.amazonaws.com'), 'host is valid');
   t.ok(validHosts.test('mapbox-satellite.s3.amazonaws.com'), 'host is valid');
   t.ok(validHosts.test('mapbox-cloudless-testing.s3.amazonaws.com'), 'host is valid');
   t.ok(validHosts.test('mapbox-pixelmonster.s3.amazonaws.com'), 'host is valid');


### PR DESCRIPTION
- adds tilestream-tilesets-production
- remove mapbox-staff and mapbox-sandbox-staff buckets from whitelist

and also tests

cc @rclark @GretaCB @willwhite 
