### PR TITLE
Upgrade tilelive to handle null extentns

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "split": "0.3.0",
     "step": "0.0.5",
     "tilejson": "^0.10.0",
-    "tilelive": "^5.6.1",
+    "tilelive": "^5.6.2",
     "tilelive-omnivore": "^1.1.6",
     "tilelive-vector": "~3.2.4",
     "tiletype": "0.1.0",


### PR DESCRIPTION
Per https://github.com/mapbox/tilelive.js/pull/119

cc @rclark 