### PR TITLE
Output a human-readable max filesize: fixes #24

### DIFF
--- a/lib/validators/omnivore.js
+++ b/lib/validators/omnivore.js
@@ -1,4 +1,5 @@
 var fs = require('fs');
+var prettyBytes = require('pretty-bytes');
 var path = require('path');
 var queue = require('queue-async');
 var invalid = require('../invalid');
@@ -32,7 +33,9 @@ module.exports = function validateOmnivore(opts, callback) {
         return memo;
       }, 0);
 
-      if (size > limits.max_filesize) return callback(invalid('File is larger than ' + limits.max_filesize + ' bytes. Too big to process.'));
+      if (size > limits.max_filesize) {
+          return callback(invalid('File is larger than ' + prettyBytes(limits.max_filesize) + '. Too big to process.'));
+      }
       callback();
     });
   });

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "mapbox-studio-pro-fonts": "https://mapbox-npm.s3.amazonaws.com/package/mapbox-studio-pro-fonts-1.0.0-9870a90b713f307b9391829602f4d5857e419615.tgz",
     "mapnik": "~3.2.0",
     "mbtiles": "^0.8.0",
+    "pretty-bytes": "^1.0.4",
     "queue-async": "^1.0.7",
     "split": "0.3.0",
     "step": "0.0.5",

--- a/test/expected/index.js
+++ b/test/expected/index.js
@@ -49,8 +49,8 @@ module.exports = {
     'gzipped': 'DeserializationError: Invalid data'
   },
   omnivoreErrors: {
-    'shpfilesize': 'File is larger than 1024 bytes. Too big to process.',
-    'tiffilesize': 'File is larger than 1024 bytes. Too big to process.',
+    'shpfilesize': 'File is larger than 1.02 kB. Too big to process.',
+    'tiffilesize': 'File is larger than 1.02 kB. Too big to process.',
     'bad-projection': 'Invalid shapefile: invalid projection file',
     'scrambled-files': 'Unknown filetype',
     'bad-bounds': 'bounds east value must be between -360 and 360',


### PR DESCRIPTION
- Adds pretty-bytes dependency
- Uses it to format error messages caused by max size being overrun

This fails tests locally with an unrelated error message.

/cc @GretaCB for the review
