### PR TITLE
Add csv filesize limit and tests

### DIFF
--- a/lib/validators/omnivore.js
+++ b/lib/validators/omnivore.js
@@ -19,6 +19,7 @@ module.exports = function validateOmnivore(opts, callback) {
     if (err) return callback(err);
 
     if (filetype === 'tif') limits = opts.limits || { max_filesize: 10 * 1024 * 1024 * 1024 };
+    if (filetype === 'csv') limits = opts.limits || { max_filesize: 5 * 1024 * 1024 };
     else limits = opts.limits || { max_filesize: 260 * 1024 * 1024 };
 
     var q = queue();

--- a/test/expected/index.js
+++ b/test/expected/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   info: {
+    'csv': require('./valid.csv.info.json'),
     'geojson': require('./valid.geojson.info.json'),
     'gpx': require('./valid.gpx.info.json'),
     'kml': require('./valid.kml.info.json'),
@@ -50,6 +51,7 @@ module.exports = {
     'gzipped': 'DeserializationError: Invalid data'
   },
   omnivoreErrors: {
+    'csvfilesize': 'File is larger than 1.02 kB. Too big to process.',
     'shpfilesize': 'File is larger than 1.02 kB. Too big to process.',
     'tiffilesize': 'File is larger than 1.02 kB. Too big to process.',
     'bad-projection': 'Invalid shapefile: invalid projection file',

--- a/test/expected/valid.csv.info.json
+++ b/test/expected/valid.csv.info.json
@@ -1,0 +1,61 @@
+{
+  "bounds": [ 
+    -77.092593, 
+    38.914278, 
+    -77.003685, 
+    38.961038 
+  ],
+  "center": [
+    -77.048139, 
+    38.937658, 
+    0
+  ],
+  "format": "pbf",
+  "vector_layers": [
+    {
+      "id": "bbl_current_csv",
+      "description": "",
+      "minzoom": 0,
+      "maxzoom": 22,
+      "fields": {
+        "BBL_LICENSE_FACT_ID": "Number",
+        "LICENSESTATUS": "String",
+        "LICENSECATEGORY": "String",
+        "CUST_NUM": "Number",
+        "TRADE_NAME": "String",
+        "LICENSE_START_DATE": "String",
+        "LICENSE_EXPIRATION_DATE": "String",
+        "LICENSE_ISSUE_DATE": "String",
+        "AGENT_PHONE": "String",
+        "LASTMODIFIEDDATE": "String",
+        "CITY": "String",
+        "STATE": "String",
+        "SITEADDRESS": "String",
+        "LATITUDE": "Number",
+        "LONGITUDE": "Number",
+        "ZIPCODE": "Number",
+        "MARADDRESSREPOSITORYID": "Number",
+        "DCSTATADDRESSKEY": "Number",
+        "DCSTATLOCATIONKEY": "Number",
+        "WARD": "Number",
+        "ANC": "String",
+        "SMD": "String",
+        "DISTRICT": "String",
+        "PSA": "Number",
+        "NEIGHBORHOODCLUSTER": "Number",
+        "HOTSPOT2006NAME": "String",
+        "HOTSPOT2005NAME": "String",
+        "HOTSPOT2004NAME": "String",
+        "BUSINESSIMPROVEMENTDISTRICT": "String"
+      }
+    }
+  ],
+  "maxzoom": 11,
+  "minzoom": 0,
+  "id": null,
+  "name": "",
+  "description": "",
+  "version": "1.0.0",
+  "legend": null,
+  "scheme": "xyz"
+}

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -3,6 +3,7 @@ var datapath = path.dirname(require.resolve('mapnik-test-data'));
 
 module.exports = {
   valid: {
+    'csv': path.join(datapath, 'data/csv/bbl_current_csv.csv'),
     'geojson': path.join(datapath, 'data/geojson/DC_polygon.geo.json'),
     'gpx': path.join(datapath, 'data/gpx/fells_loop.gpx'),
     'kml': path.join(datapath, 'data/kml/1week_earthquake.kml'),

--- a/test/validate.test.js
+++ b/test/validate.test.js
@@ -10,6 +10,7 @@ process.env.MapboxAPIMaps = 'https://api.tiles.mapbox.com';
 var validFiletypes = Object.keys(fixtures.valid);
 var validProtocols = validFiletypes.map(function(k) {
   if (k.indexOf('mbtiles') === 0) return 'mbtiles:';
+  if (k === 'csv') return 'omnivore:';
   if (k === 'shp') return 'omnivore:';
   if (k === 'tif') return 'omnivore:';
   if (k === 'geojson') return 'omnivore:';

--- a/test/validators.omnivore.test.js
+++ b/test/validators.omnivore.test.js
@@ -43,3 +43,12 @@ test('lib.validators.omnivore: tif file too big', function(t) {
     t.equal(err.message, expected.omnivoreErrors.tiffilesize, 'expected error message');
   });
 });
+
+test('lib.validators.omnivore: csv file too big', function(t) {
+  t.plan(3); // assert that callback is not fired more than once
+  validate(fixtures.valid.csv, 1024, function(err) {
+    t.ok(err, 'expected error');
+    t.equal(err.code, 'EINVALID', 'expected error code');
+    t.equal(err.message, expected.omnivoreErrors.csvfilesize, 'expected error message');
+  });
+});


### PR DESCRIPTION
CSV is a very inefficient format to parse and we should start small. Can always increase in the future.

cc @springmeyer 