### PR TITLE
Fixes logic to allow tif size limit to be respected

### DIFF
--- a/lib/validators/omnivore.js
+++ b/lib/validators/omnivore.js
@@ -20,7 +20,7 @@ module.exports = function validateOmnivore(opts, callback) {
     if (err) return callback(err);
 
     if (filetype === 'tif') limits = opts.limits || uploadLimits.tif;
-    if (filetype === 'csv') limits = opts.limits || uploadLimits.csv;
+    else if (filetype === 'csv') limits = opts.limits || uploadLimits.csv;
     else limits = opts.limits || uploadLimits.omnivoreOther;
 
     var q = queue();
@@ -36,7 +36,7 @@ module.exports = function validateOmnivore(opts, callback) {
       }, 0);
 
       if (size > limits.max_filesize) {
-          return callback(invalid('File is larger than ' + prettyBytes(limits.max_filesize) + '. Too big to process.'));
+        return callback(invalid('File is larger than ' + prettyBytes(limits.max_filesize) + '. Too big to process.'));
       }
       callback();
     });


### PR DESCRIPTION
Missing `else` meant tif files were locked into the default omnivore size limit (270MB) instead of the intended 10GB.