### PR TITLE
Refactor serialtiles validation

### DIFF
--- a/lib/validators/serialtiles.js
+++ b/lib/validators/serialtiles.js
@@ -7,79 +7,104 @@ var mapnik = require('mapnik');
 var tiletype = require('tiletype');
 var stream = require('stream');
 
-// The only additional validation performed on serialtiles is based on the size
-// of any individual tile, which means deserializing the whole set and checking
-// every tile's size.
-// This might make sense in some contexts, and in others you might just skip this
-// step and let it come out during a tilelive-copy operation
+module.exports = validateSerialtiles;
+module.exports.validType = validType;
+module.exports.validLength = validLength;
+module.exports.validVectoTile = validVectorTile;
+module.exports.ValidationStream = ValidationStream;
 
-module.exports = function validateSerialtiles(opts, callback) {
+function validateSerialtiles(opts, callback) {
   if (process.env.SkipSerialtilesValidation) return callback();
   var limits = opts.limits || uploadLimits.serialtiles;
-  var errored = false;
 
-  var writable = new stream.Writable({ objectMode: true });
-  writable._write = function(tile, enc, cb) {
-    if (errored) return cb();
-    if (!tile.buffer) return cb();
-
-    var format = tiletype.type(tile.buffer);
-
-    if (!format) {
-      cb(invalid('Invalid tiletype'));
-      errored = true;
-      return read.close();
-    }
-
-    if (tile.buffer.length > limits.max_tilesize) {
-      cb(invalid('Tile exceeds maximum size of ' + Math.round(limits.max_tilesize / 1024) + 'k at z' + tile.z + '. Reduce the detail of data at this zoom level or omit it by adjusting your minzoom.'));
-      errored = true;
-      return read.close();
-    }
-
-    if (format !== 'pbf') return cb();
-
-    var vtile = new mapnik.VectorTile(tile.z, tile.x, tile.y);
-
-    zlib.gunzip(tile.buffer, function(err, data) {
-      if (err) return cb(invalid(err.message));
-
-      vtile.setData(data, function(err) {
-        if (err) return cb(invalid(err.message));
-
-        try { vtile.parse(); }
-        catch (err) {
-          err.name = 'DeserializationError';
-          err.message = 'Invalid data';
-          return cb(err);
-        }
-
-        if (vtile.empty()) return cb(invalid('Tile is empty'));
-
-        var json = vtile.toJSON();
-        if (!json[0] || !json[0].name) return cb(invalid('Tile has no layers'));
-        if (!json[0] || !json[0].features) return cb(invalid('Tile has no features'));
-
-        return cb();
-      });
-    });
-  };
+  var validationStream = ValidationStream({
+    sizeLimit: limits.max_tilesize,
+    validateVectorTiles: true
+  });
 
   function fail(err) {
-    if (!errored) {
-      if (err.name === 'DeserializationError') return callback(invalid('%s: %s', err.name, err.message));
-      else return callback(err);
-    }
-    errored = true;
+    if (err.name === 'DeserializationError') return callback(invalid('%s: %s', err.name, err.message));
+    else return callback(err);
   }
 
   var read = fs.createReadStream(opts.filepath);
   read.pipe(zlib.createGunzip())
     .pipe(tilelive.deserialize())
     .once('error', fail)
-    .pipe(writable)
+    .pipe(validationStream)
     .once('error', fail)
-    .on('finish', function() {
-      if (!errored) return callback();
+    .on('finish', callback).resume();
+}
+
+function validType(tile) {
+  return tiletype.type(tile.buffer);
+}
+
+function validLength(tile, limit) {
+  limit = limit || uploadLimits.serialtiles.max_tilesize;
+  return tile.buffer.length <= limit;
+}
+
+function validVectorTile(tile, callback) {
+  var vtile = new mapnik.VectorTile(tile.z, tile.x, tile.y);
+
+  zlib.gunzip(tile.buffer, function(err, data) {
+    if (err) return callback(invalid(err.message));
+
+    vtile.setData(data, function(err) {
+      if (err) return callback(invalid(err.message));
+
+      try { vtile.parse(); }
+      catch (parseErr) {
+        parseErr.name = 'DeserializationError';
+        parseErr.message = 'Invalid data';
+        return callback(parseErr);
+      }
+
+      if (vtile.empty()) return callback(invalid('Tile is empty'));
+
+      var json = vtile.toJSON();
+      if (!json[0] || !json[0].name) return callback(invalid('Tile has no layers'));
+      if (!json[0] || !json[0].features) return callback(invalid('Tile has no features'));
+
+      return callback();
     });
-};
+  });
+}
+
+function ValidationStream(options) {
+  var validationStream = new stream.Transform({ objectMode: true });
+  validationStream.tiles = 0;
+  validationStream.max = options.numTiles || Infinity;
+
+  validationStream._transform = function(tile, enc, callback) {
+    if (!tile.buffer) return callback();
+
+    if (validationStream.tiles >= validationStream.max) {
+      validationStream.push(tile);
+      validationStream.tiles++;
+      return callback();
+    }
+
+    var format = validType(tile);
+    if (!format) return callback(invalid('Invalid tiletype'));
+
+    if (!validLength(tile, options.sizeLimit))
+      return callback(invalid('Tile exceeds maximum size of ' + Math.round(options.sizeLimit / 1024) + 'k at z' + tile.z + '. Reduce the detail of data at this zoom level or omit it by adjusting your minzoom.'));
+
+    if (!options.validateVectorTiles || format !== 'pbf') {
+      validationStream.push(tile);
+      validationStream.tiles++;
+      return callback();
+    }
+
+    validVectorTile(tile, function(err) {
+      if (err) return callback(err);
+      validationStream.push(tile);
+      validationStream.tiles++;
+      return callback();
+    });
+  };
+
+  return validationStream;
+}


### PR DESCRIPTION
Breaks up the process of serialtiles validation. Provides functions to validate tile type, tile size, and vector tile content. Also provides a configurable transform stream. The idea here that that these functions could be used in a tilelive.copy operation (https://github.com/mapbox/tilelive.js/issues/130).

