### PR TITLE
Skippable vector tile validation

### DIFF
--- a/lib/validators/serialtiles.js
+++ b/lib/validators/serialtiles.js
@@ -19,7 +19,7 @@ function validateSerialtiles(opts, callback) {
 
   var validationStream = ValidationStream({
     sizeLimit: limits.max_tilesize,
-    validateVectorTiles: true
+    validateVectorTiles: process.env.SkipVectorTileValidation ? false : true
   });
 
   function fail(err) {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "tilejson": "^0.13.0",
     "tilelive": "^5.7.0",
     "tilelive-omnivore": "~1.2.0",
-    "tilelive-vector": "~3.2.5",
+    "tilelive-vector": "~3.2.7",
     "tiletype": "0.1.0",
     "underscore": "^1.7.0"
   },

--- a/test/validators.serialtiles.test.js
+++ b/test/validators.serialtiles.test.js
@@ -37,7 +37,7 @@ test('lib.validators.serialtiles: tile too big', function(t) {
 });
 
 test('lib.validators.serialtiles: invalid gzipped file format', function(t) {
-  t.plan(3); 
+  t.plan(3);
   validate(fixtures.invalid.serialtiles.gzipped, function(err) {
     t.ok(err, 'expected error');
     t.equal(err.code, 'EINVALID', 'expected error code');
@@ -55,7 +55,7 @@ test('lib.validators.serialtiles: failure to deserialize', function(t) {
 });
 
 test('lib.validators.serialtiles: invalid tiletype', function(t) {
-  t.plan(3); 
+  t.plan(3);
   validate(fixtures.invalid.serialtiles.tiletype, function(err) {
     t.ok(err, 'expected error');
     t.equal(err.code, 'EINVALID', 'expected error code');
@@ -74,6 +74,14 @@ test('lib.validators.serialtiles: valid PBF', function(t) {
 test('lib.validators.serialtiles: valid PNG', function(t) {
   t.plan(1);
   validate(fixtures.valid.serialtiles_png, function(err) {
+    t.ifError(err, 'no error');
+    t.end();
+  });
+});
+
+test('lib.validators.serialtiles: skip vector-tile validation', function(t) {
+  process.env.SkipVectorTileValidation = 1;
+  validate(fixtures.invalid.serialtiles.gzipped, function(err) {
     t.ifError(err, 'no error');
     t.end();
   });


### PR DESCRIPTION
Allows full vector-tile validation (of serialtiles) to be skipped via an environment variable flag.