### PR TITLE
Update tilelive-omnivore dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "mapbox-upload-limits": "^1.0.4",
     "mapnik": "~3.4.11",
     "mbtiles": "^0.8.0",
-    "pretty-bytes": "^1.0.4",
+    "pretty-bytes": "^3.0.0",
     "queue-async": "^1.0.7",
     "split": "~1.0.0",
     "step": "~0.0.6",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "step": "0.0.5",
     "tilejson": "^0.13.0",
     "tilelive": "~5.11.0",
-    "tilelive-omnivore": "~2.0.0",
+    "tilelive-omnivore": "~2.1.0",
     "tilelive-vector": "~3.5.0",
     "tiletype": "0.1.0",
     "underscore": "^1.7.0"

--- a/package.json
+++ b/package.json
@@ -29,13 +29,13 @@
     "mbtiles": "^0.8.0",
     "pretty-bytes": "^1.0.4",
     "queue-async": "^1.0.7",
-    "split": "0.3.0",
-    "step": "0.0.5",
+    "split": "~1.0.0",
+    "step": "~0.0.6",
     "tilejson": "^0.13.0",
     "tilelive": "~5.11.0",
     "tilelive-omnivore": "~2.1.0",
     "tilelive-vector": "~3.5.0",
-    "tiletype": "0.1.0",
+    "tiletype": "~0.3.0",
     "underscore": "^1.7.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Tilelive-omnivore 2.0.0 was breaking mapnik-swoop with it's downstream gdal dependency. Updating this fixes mapnik-swoop. This branch may be used later on for updating to mapnik 3.5.0.

cc/ @mapsam @springmeyer @flippmoke 