### PR TITLE
[WIP] Use tilelive.copy to validate vtiles in mbtiles

### DIFF
--- a/lib/validationstream.js
+++ b/lib/validationstream.js
@@ -28,7 +28,7 @@ function validVectorTile(tile, callback) {
   // but tests currently check for DeserializationError.
   if (info.errors) {
     error = {
-      name: 'DeserializationError',
+      name: 'ValidityError',
       message: 'Invalid data'      
     };
     return callback(error);
@@ -36,7 +36,7 @@ function validVectorTile(tile, callback) {
 
   if (info.layers.some(function(layer) { return layer.version === 1; })) {
     error = {
-      name: 'DeserializationError',
+      name: 'ValidityError',
       message: 'v1 vector tile'
     };
     return callback(error);

--- a/lib/validationstream.js
+++ b/lib/validationstream.js
@@ -21,14 +21,23 @@ function validLength(tile, limit) {
 
 function validVectorTile(tile, callback) {
   var info = mapnik.VectorTile.info(tile.buffer);
+  var error;
 
   // Right now we are just sending a generic error response.
   // We can return more info from Node Mapnik if we need
   // but tests currently check for DeserializationError.
   if (info.errors) {
-    var error = {
+    error = {
       name: 'DeserializationError',
       message: 'Invalid data'      
+    };
+    return callback(error);
+  }
+
+  if (info.layers.some(function(layer) { return layer.version === 1; })) {
+    error = {
+      name: 'DeserializationError',
+      message: 'v1 vector tile'
     };
     return callback(error);
   }
@@ -42,7 +51,11 @@ function ValidationStream(options) {
   validationStream.max = options.numTiles || Infinity;
 
   validationStream._transform = function(tile, enc, callback) {
-    if (!tile.buffer) return callback();
+    if (!tile.buffer) {
+      validationStream.push(tile);
+      validationStream.tiles++;
+      return callback();
+    }
 
     if (validationStream.tiles >= validationStream.max) {
       validationStream.push(tile);

--- a/lib/validators/mbtiles.js
+++ b/lib/validators/mbtiles.js
@@ -1,10 +1,12 @@
 var fs = require('fs');
+var stream = require('stream');
 var tiletype = require('tiletype');
 var uploadLimits = require('mapbox-upload-limits');
 var invalid = require('../invalid');
 var queue = require('queue-async');
 var prettyBytes = require('pretty-bytes');
-var mapnik = require('mapnik');
+var ValidationStream = require('../validationstream');
+var tilelive = require('tilelive');
 
 module.exports = function validateMbtiles(opts, callback) {
   var limits = opts.limits || uploadLimits.mbtiles;
@@ -14,11 +16,11 @@ module.exports = function validateMbtiles(opts, callback) {
 
   queue()
     .defer(validFormat, opts.source._db, opts.info)
-    .defer(validateTileStream, opts.source, opts.info)
     .defer(deprecatedCarmen, opts.source._db)
     .defer(fileSize, opts.filepath, limits)
     .defer(dataCounts, opts.source._db, limits)
-    .await(callback);
+    .defer(validateTileStream, opts.filepath, limits)
+    .awaitAll(callback);
 };
 
 function sqliteError(err) {
@@ -52,55 +54,75 @@ function validFormat(db, info, callback) {
   });
 }
 
-function validateTileStream(source, info, callback) {
+function validateTileStream(filepath, limits, callback) {
   if (process.env.SkipVectorTileValidation) return callback();
 
-  // we can specify a batch size here if we want
-  // default is 1000 lines { batch: 1000 }
-  var stream = source.createZXYStream();
-  var is_done = false;
+  var src = filepath;
+  var dst = false;
+  var devnull = new stream.Writable();
+  devnull._write = function (chunk, enc, next) {
+    next();
+  };
+  var options = {
+    progress: false,//report,
+    transform: ValidationStream({
+      validateVectorTiles: process.env.SkipVectorTileValidation ? false : true
+    }),
+    outStream: devnull,
+    close: true,
+    retry: 0,
+    concurrency: 10
+  };
 
-  function done(err) {
-    if (!is_done) {
-      is_done = true;
-      return callback(err);
-    }
+  /*
+  function report(stats, p) {
+    console.log(require('util').format('\r\033[K[%s] %s%% %s/%s @ %s/s | ✓ %s □ %s | %s left',
+      pad(formatDuration(process.uptime()), 4, true),
+      pad((p.percentage).toFixed(4), 8, true),
+      pad(formatNumber(p.transferred),6,true),
+      pad(formatNumber(p.length),6,true),
+      pad(formatNumber(p.speed),4,true),
+      formatNumber(stats.done - stats.skipped),
+      formatNumber(stats.skipped),
+      formatDuration(p.eta)
+    ));
   }
 
-  stream.on('data', function(lines) {
-    if (!is_done) {
-      var buffers = lines.toString().split('\n');
-      var q = queue();
-      
-      buffers.forEach(function(line) {
-        if (line.length > 0) q.defer(validateTile, source, line);
-      });
+  function formatDuration(duration) {
+    var seconds = duration % 60;
+    duration -= seconds;
+    var minutes = (duration % 3600) / 60;
+    duration -= minutes * 60;
+    var hours = (duration % 86400) / 3600;
+    duration -= hours * 3600;
+    var days = duration / 86400;
 
-      q.awaitAll(function(err) {
-        if (err) return done(err);
-      });      
+    return (days > 0 ? days + 'd ' : '') +
+      (hours > 0 || days > 0 ? hours + 'h ' : '') +
+      (minutes > 0 || hours > 0 || days > 0 ? minutes + 'm ' : '') +
+      seconds + 's';
+  }
+
+  function pad(str, len, r) {
+    while (str.length < len) str = r ? ' ' + str : str + ' ';
+      return str;
+  }
+
+  function formatNumber(num) {
+    num = num || 0;
+    if (num >= 1e6) {
+      return (num / 1e6).toFixed(2) + 'm';
+    } else if (num >= 1e3) {
+      return (num / 1e3).toFixed(1) + 'k';
+    } else {
+      return num.toFixed(0);
     }
-  });
+    return num.join('.');
+  }
+  */
 
-  stream.on('end', function() {
-    return done();
-  });
-  
-}
-
-function validateTile(source, line, callback) {
-  var zxy = line.split('/');
-  source.getTile(zxy[0], zxy[1], zxy[2], function(err, buffer) {
+  tilelive.copy(src, dst, options, function(err) {
     if (err) return callback(err);
-    
-    var info = mapnik.VectorTile.info(buffer);
-    if (info.errors) {
-      var error = {
-        name: 'DeserializationError',
-        message: 'Invalid data'
-      };
-      return callback(error);
-    }
 
     return callback();
   });

--- a/lib/validators/mbtiles.js
+++ b/lib/validators/mbtiles.js
@@ -64,7 +64,6 @@ function validateTileStream(filepath, limits, callback) {
     next();
   };
   var options = {
-    progress: false,//report,
     transform: ValidationStream({
       validateVectorTiles: process.env.SkipVectorTileValidation ? false : true
     }),
@@ -74,54 +73,8 @@ function validateTileStream(filepath, limits, callback) {
     concurrency: 10
   };
 
-  /*
-  function report(stats, p) {
-    console.log(require('util').format('\r\033[K[%s] %s%% %s/%s @ %s/s | ✓ %s □ %s | %s left',
-      pad(formatDuration(process.uptime()), 4, true),
-      pad((p.percentage).toFixed(4), 8, true),
-      pad(formatNumber(p.transferred),6,true),
-      pad(formatNumber(p.length),6,true),
-      pad(formatNumber(p.speed),4,true),
-      formatNumber(stats.done - stats.skipped),
-      formatNumber(stats.skipped),
-      formatDuration(p.eta)
-    ));
-  }
-
-  function formatDuration(duration) {
-    var seconds = duration % 60;
-    duration -= seconds;
-    var minutes = (duration % 3600) / 60;
-    duration -= minutes * 60;
-    var hours = (duration % 86400) / 3600;
-    duration -= hours * 3600;
-    var days = duration / 86400;
-
-    return (days > 0 ? days + 'd ' : '') +
-      (hours > 0 || days > 0 ? hours + 'h ' : '') +
-      (minutes > 0 || hours > 0 || days > 0 ? minutes + 'm ' : '') +
-      seconds + 's';
-  }
-
-  function pad(str, len, r) {
-    while (str.length < len) str = r ? ' ' + str : str + ' ';
-      return str;
-  }
-
-  function formatNumber(num) {
-    num = num || 0;
-    if (num >= 1e6) {
-      return (num / 1e6).toFixed(2) + 'm';
-    } else if (num >= 1e3) {
-      return (num / 1e3).toFixed(1) + 'k';
-    } else {
-      return num.toFixed(0);
-    }
-    return num.join('.');
-  }
-  */
-
   tilelive.copy(src, dst, options, function(err) {
+    if (err && err.name === 'ValidityError') return callback(invalid(err.message)); 
     if (err) return callback(err);
 
     return callback();

--- a/lib/validators/serialtiles.js
+++ b/lib/validators/serialtiles.js
@@ -18,7 +18,7 @@ function validateSerialtiles(opts, callback) {
   });
 
   function fail(err) {
-    if (err.name === 'DeserializationError') return callback(invalid('%s: %s', err.name, err.message));
+    if (err.name === 'ValidityError' || err.name === 'DeserializationError') return callback(invalid('%s: %s', err.name, err.message));
     else return callback(err);
   }
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "split": "~1.0.0",
     "step": "~0.0.6",
     "tilejson": "^0.13.0",
-    "tilelive": "https://github.com/mapbox/tilelive#82249a5001c15ac261febc6c2933a53c5d0c195a",
+    "tilelive": "git://github.com/mapbox/tilelive.git#82249a5001c15ac261febc6c2933a53c5d0c195a",
     "tilelive-omnivore": "~2.2.0",
     "tilelive-vector": "~3.9.1",
     "tiletype": "~0.3.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "split": "~1.0.0",
     "step": "~0.0.6",
     "tilejson": "^0.13.0",
-    "tilelive": "~5.12.0",
+    "tilelive": "https://github.com/mapbox/tilelive#82249a5001c15ac261febc6c2933a53c5d0c195a",
     "tilelive-omnivore": "~2.2.0",
     "tilelive-vector": "~3.9.1",
     "tiletype": "~0.3.0",

--- a/test/validators.mbtiles.test.js
+++ b/test/validators.mbtiles.test.js
@@ -111,7 +111,6 @@ test('lib.validators.mbtiles: file too big', function(t) {
     t.ok(err, 'expected error');
     t.equal(err.code, 'EINVALID', 'expected error code');
     t.equal(err.message, expected.mbtilesErrors.filetoobig, 'expected error message');
-    console.log('made it here?');
     t.end();
   });
 });

--- a/test/validators.mbtiles.test.js
+++ b/test/validators.mbtiles.test.js
@@ -111,6 +111,7 @@ test('lib.validators.mbtiles: file too big', function(t) {
     t.ok(err, 'expected error');
     t.equal(err.code, 'EINVALID', 'expected error code');
     t.equal(err.message, expected.mbtilesErrors.filetoobig, 'expected error message');
+    console.log('made it here?');
     t.end();
   });
 });


### PR DESCRIPTION
@mapsam this is a PR into the `every-tile` branch that changes the logic to use tilelive-copy. Still lots of bugs that need to be worked out, but hopefully we'll get this ready to ship.

The next step would be adding this transform stream in `mapbox-tile-copy` as a `transform` option in its call to `tilelive.copy` (refs https://github.com/mapbox/mapbox-tile-copy/blob/master/lib/tilelivecopy.js#L53). We'll need to adapt the `tilelive.copy` function to accept an array of transform streams, since there isn't a good way to combine transform streams into one transform stream, and we need a way to have a stats transform and validation transform on mbtiles files.

cc/ @springmeyer @flippmoke @rclark 