### PR TITLE
Validate every tile

### DIFF
--- a/lib/validationstream.js
+++ b/lib/validationstream.js
@@ -33,14 +33,6 @@ function validVectorTile(tile, callback) {
     return callback(error);
   }
 
-  if (info.layers.some(function(layer) { return layer.version === 1; })) {
-    error = {
-      name: 'ValidityError',
-      message: 'v1 vector tile'
-    };
-    return callback(error);
-  }
-
   return callback();
 }
 

--- a/lib/validationstream.js
+++ b/lib/validationstream.js
@@ -3,7 +3,6 @@ var tiletype = require('tiletype');
 var mapnik = require('mapnik');
 var stream = require('stream');
 var uploadLimits = require('mapbox-upload-limits');
-var zlib = require('zlib');
 var invalid = require('./invalid');
 
 module.exports = ValidationStream;
@@ -21,23 +20,20 @@ function validLength(tile, limit) {
 }
 
 function validVectorTile(tile, callback) {
-  var vtile = new mapnik.VectorTile(tile.z, tile.x, tile.y);
+  var info = mapnik.VectorTile.info(tile.buffer);
 
-  zlib.gunzip(tile.buffer, function(err, data) {
-    if (err) return callback(invalid(err.message));
+  // Right now we are just sending a generic error response.
+  // We can return more info from Node Mapnik if we need
+  // but tests currently check for DeserializationError.
+  if (info.errors) {
+    var error = {
+      name: 'DeserializationError',
+      message: 'Invalid data'      
+    };
+    return callback(error);
+  }
 
-    vtile.setData(data, function(err) {
-      if (err) {
-        err.name = 'DeserializationError';
-        err.message = 'Invalid data';
-        return callback(err);
-      }
-
-      if (vtile.empty()) return callback(invalid('Tile is empty'));
-
-      return callback();
-    });
-  });
+  return callback();
 }
 
 function ValidationStream(options) {

--- a/lib/validationstream.js
+++ b/lib/validationstream.js
@@ -1,7 +1,6 @@
 var stream = require('stream');
 var tiletype = require('tiletype');
 var mapnik = require('mapnik');
-var stream = require('stream');
 var uploadLimits = require('mapbox-upload-limits');
 var invalid = require('./invalid');
 

--- a/lib/validationstream.js
+++ b/lib/validationstream.js
@@ -4,7 +4,7 @@ var mapnik = require('mapnik');
 var stream = require('stream');
 var uploadLimits = require('mapbox-upload-limits');
 var zlib = require('zlib');
-var invalid = require('../invalid');
+var invalid = require('./invalid');
 
 module.exports = ValidationStream;
 module.exports.validType = validType;

--- a/lib/validators/mbtiles.js
+++ b/lib/validators/mbtiles.js
@@ -4,6 +4,7 @@ var uploadLimits = require('mapbox-upload-limits');
 var invalid = require('../invalid');
 var queue = require('queue-async');
 var prettyBytes = require('pretty-bytes');
+var mapnik = require('mapnik');
 
 module.exports = function validateMbtiles(opts, callback) {
   var limits = opts.limits || uploadLimits.mbtiles;
@@ -13,6 +14,7 @@ module.exports = function validateMbtiles(opts, callback) {
 
   queue()
     .defer(validFormat, opts.source._db, opts.info)
+    .defer(validateTileStream, opts.source, opts.info)
     .defer(deprecatedCarmen, opts.source._db)
     .defer(fileSize, opts.filepath, limits)
     .defer(dataCounts, opts.source._db, limits)
@@ -47,6 +49,60 @@ function validFormat(db, info, callback) {
       return callback(invalid('Vector source must include "vector_layers" key'));
 
     callback();
+  });
+}
+
+function validateTileStream(source, info, callback) {
+  if (process.env.SkipVectorTileValidation) return callback();
+
+  // we can specify a batch size here if we want
+  // default is 1000 lines { batch: 1000 }
+  var stream = source.createZXYStream();
+  var is_done = false;
+
+  function done(err) {
+    if (!is_done) {
+      is_done = true;
+      return callback(err);
+    }
+  }
+
+  stream.on('data', function(lines) {
+    if (!is_done) {
+      var buffers = lines.toString().split('\n');
+      var q = queue();
+      
+      buffers.forEach(function(line) {
+        if (line.length > 0) q.defer(validateTile, source, line);
+      });
+
+      q.awaitAll(function(err) {
+        if (err) return done(err);
+      });      
+    }
+  });
+
+  stream.on('end', function() {
+    return done();
+  });
+  
+}
+
+function validateTile(source, line, callback) {
+  var zxy = line.split('/');
+  source.getTile(zxy[0], zxy[1], zxy[2], function(err, buffer) {
+    if (err) return callback(err);
+    
+    var info = mapnik.VectorTile.info(buffer);
+    if (info.errors) {
+      var error = {
+        name: 'DeserializationError',
+        message: 'Invalid data'
+      };
+      return callback(error);
+    }
+
+    return callback();
   });
 }
 

--- a/lib/validators/serialtiles.js
+++ b/lib/validators/serialtiles.js
@@ -3,16 +3,10 @@ var uploadLimits = require('mapbox-upload-limits');
 var fs = require('fs');
 var zlib = require('zlib');
 var invalid = require('../invalid');
-var mapnik = require('mapnik');
-var tiletype = require('tiletype');
-var stream = require('stream');
 var prettyBytes = require('pretty-bytes');
+var ValidationStream = require('./validationstream');
 
 module.exports = validateSerialtiles;
-module.exports.validType = validType;
-module.exports.validLength = validLength;
-module.exports.validVectoTile = validVectorTile;
-module.exports.ValidationStream = ValidationStream;
 
 function validateSerialtiles(opts, callback) {
   if (process.env.SkipSerialtilesValidation) return callback();
@@ -43,70 +37,4 @@ function validateSerialtiles(opts, callback) {
       .once('error', fail)
       .on('finish', callback).resume();
   });
-}
-
-function validType(tile) {
-  return tiletype.type(tile.buffer);
-}
-
-function validLength(tile, limit) {
-  limit = limit || uploadLimits.serialtiles.max_tilesize;
-  return tile.buffer.length <= limit;
-}
-
-function validVectorTile(tile, callback) {
-  var vtile = new mapnik.VectorTile(tile.z, tile.x, tile.y);
-
-  zlib.gunzip(tile.buffer, function(err, data) {
-    if (err) return callback(invalid(err.message));
-
-    vtile.setData(data, function(err) {
-      if (err) {
-        err.name = 'DeserializationError';
-        err.message = 'Invalid data';
-        return callback(err);
-      }
-
-      if (vtile.empty()) return callback(invalid('Tile is empty'));
-
-      return callback();
-    });
-  });
-}
-
-function ValidationStream(options) {
-  var validationStream = new stream.Transform({ objectMode: true });
-  validationStream.tiles = 0;
-  validationStream.max = options.numTiles || Infinity;
-
-  validationStream._transform = function(tile, enc, callback) {
-    if (!tile.buffer) return callback();
-
-    if (validationStream.tiles >= validationStream.max) {
-      validationStream.push(tile);
-      validationStream.tiles++;
-      return callback();
-    }
-
-    var format = validType(tile);
-    if (!format) return callback(invalid('Invalid tiletype'));
-
-    if (!validLength(tile, options.sizeLimit))
-      return callback(invalid('Tile exceeds maximum size of ' + Math.round(options.sizeLimit / 1024) + 'k at z' + tile.z + '. Reduce the detail of data at this zoom level or omit it by adjusting your minzoom.'));
-
-    if (!options.validateVectorTiles || format !== 'pbf') {
-      validationStream.push(tile);
-      validationStream.tiles++;
-      return callback();
-    }
-
-    validVectorTile(tile, function(err) {
-      if (err) return callback(err);
-      validationStream.push(tile);
-      validationStream.tiles++;
-      return callback();
-    });
-  };
-
-  return validationStream;
 }

--- a/lib/validators/serialtiles.js
+++ b/lib/validators/serialtiles.js
@@ -4,12 +4,12 @@ var fs = require('fs');
 var zlib = require('zlib');
 var invalid = require('../invalid');
 var prettyBytes = require('pretty-bytes');
-var ValidationStream = require('./validationstream');
+var ValidationStream = require('../validationstream');
 
 module.exports = validateSerialtiles;
 
 function validateSerialtiles(opts, callback) {
-  if (process.env.SkipSerialtilesValidation) return callback();
+  if (process.env.SkipVectorTileValidation) return callback();
   var limits = opts.limits || uploadLimits.serialtiles;
 
   var validationStream = ValidationStream({

--- a/lib/validators/validationstream.js
+++ b/lib/validators/validationstream.js
@@ -1,0 +1,79 @@
+var stream = require('stream');
+var tiletype = require('tiletype');
+var mapnik = require('mapnik');
+var stream = require('stream');
+var uploadLimits = require('mapbox-upload-limits');
+var zlib = require('zlib');
+var invalid = require('../invalid');
+
+module.exports = ValidationStream;
+module.exports.validType = validType;
+module.exports.validLength = validLength;
+module.exports.validVectorTile = validVectorTile;
+
+function validType(tile) {
+  return tiletype.type(tile.buffer);
+}
+
+function validLength(tile, limit) {
+  limit = limit || uploadLimits.serialtiles.max_tilesize;
+  return tile.buffer.length <= limit;
+}
+
+function validVectorTile(tile, callback) {
+  var vtile = new mapnik.VectorTile(tile.z, tile.x, tile.y);
+
+  zlib.gunzip(tile.buffer, function(err, data) {
+    if (err) return callback(invalid(err.message));
+
+    vtile.setData(data, function(err) {
+      if (err) {
+        err.name = 'DeserializationError';
+        err.message = 'Invalid data';
+        return callback(err);
+      }
+
+      if (vtile.empty()) return callback(invalid('Tile is empty'));
+
+      return callback();
+    });
+  });
+}
+
+function ValidationStream(options) {
+  var validationStream = new stream.Transform({ objectMode: true });
+  validationStream.tiles = 0;
+  validationStream.max = options.numTiles || Infinity;
+
+  validationStream._transform = function(tile, enc, callback) {
+    if (!tile.buffer) return callback();
+
+    if (validationStream.tiles >= validationStream.max) {
+      validationStream.push(tile);
+      validationStream.tiles++;
+      return callback();
+    }
+
+    var format = validType(tile);
+    if (!format) return callback(invalid('Invalid tiletype'));
+
+    if (!validLength(tile, options.sizeLimit))
+      return callback(invalid('Tile exceeds maximum size of ' + Math.round(options.sizeLimit / 1024) + 'k at z' + tile.z + '. Reduce the detail of data at this zoom level or omit it by adjusting your minzoom.'));
+
+    if (!options.validateVectorTiles || format !== 'pbf') {
+      validationStream.push(tile);
+      validationStream.tiles++;
+      return callback();
+    }
+
+    validVectorTile(tile, function(err) {
+      if (err) return callback(err);
+      validationStream.push(tile);
+      validationStream.tiles++;
+      return callback();
+    });
+  };
+
+  return validationStream;
+}
+

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "split": "~1.0.0",
     "step": "~0.0.6",
     "tilejson": "^0.13.0",
-    "tilelive": "git://github.com/mapbox/tilelive.git#82249a5001c15ac261febc6c2933a53c5d0c195a",
+    "tilelive": "~5.12.2",
     "tilelive-omnivore": "~2.2.0",
     "tilelive-vector": "~3.9.1",
     "tiletype": "~0.3.0",

--- a/test/expected/index.js
+++ b/test/expected/index.js
@@ -47,9 +47,9 @@ module.exports = {
   serialtilesErrors: {
     'tilesize': 'Tile exceeds maximum size of 1k at z1. Reduce the detail of data at this zoom level or omit it by adjusting your minzoom.',
     'noinfo': 'Missing Info object',
-    'cantdeserialize': 'DeserializationError: Invalid data',
+    'cantdeserialize': 'ValidityError: Invalid data',
     'tiletype': 'Invalid tiletype',
-    'gzipped': 'DeserializationError: Invalid data',
+    'gzipped': 'ValidityError: Invalid data',
     'filetoobig': 'File is larger than 1.02 kB. Too big to process.'
   },
   omnivoreErrors: {

--- a/test/validators.serialtiles.test.js
+++ b/test/validators.serialtiles.test.js
@@ -90,14 +90,6 @@ test('lib.validators.serialtiles: valid PNG', function(t) {
 
 test('lib.validators.serialtiles: skip vector-tile validation', function(t) {
   process.env.SkipVectorTileValidation = 1;
-  validate(fixtures.invalid.serialtiles.gzipped, function(err) {
-    t.ifError(err, 'no error');
-    t.end();
-  });
-});
-
-test('lib.validators.serialtiles: skip', function(t) {
-  process.env.SkipSerialtilesValidation = 1;
   validate(fixtures.valid.serialtiles, { max_tilesize: 1024 }, function(err) {
     t.ifError(err, 'no error');
     t.end();


### PR DESCRIPTION
This PR aims to add complete tile validation for serialtiles and mbtiles in preparation for v2 vector tiles. The goal is to:

* validate ALL mbtiles and serialtiles tiles via `validationstream.js` using [`mapnik.VectorTile.info()`](http://mapnik.org/node-mapnik/documentation/3.5/#VectorTile.info) and the information it returns (such as `version` and `errors`)
* make `validationstream.js` useable outside of mapbox upload validate, specifically for validation in `mapbox-tile-copy`

cc/ @jakepruitt @flippmoke @springmeyer @GretaCB @rclark @yhahn 