### PR TITLE
Optimize validation steps

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 var validate = require('./lib/validate');
-var Step = require('step');
 
 module.exports = function(filepath, callback) {
   var results = {};
@@ -9,31 +8,8 @@ module.exports = function(filepath, callback) {
     if (err && err.code === 'EINVALID') return callback(null, false, err.message);
     return callback(err);
   }
-
-  Step(
-    function() {
-      validate.filepath(filepath, this);
-    },
-    function(err, protocol) {
-      if (err) return fail(err);
-      results.filepath = filepath;
-      results.protocol = protocol;
-      results.uri = protocol + '//' + filepath;
-      validate.info(results.uri, this);
-    },
-    function(err, info) {
-      if (err) return fail(err);
-      results.info = info;
-      validate.source(results.uri, this);
-    },
-    function(err, source) {
-      if (err) return fail(err);
-      results.source = source;
-      validate[results.protocol.slice(0,-1)](results, this);
-    },
-    function(err) {
-      if (err) return fail(err);
-      callback(null, true);
-    }
-  );
+  return validate(filepath,function(err) {
+    if (err) return fail(err);
+    return callback(null,true);
+  });
 };

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -1,6 +1,5 @@
 var sniffer = require('mapbox-file-sniff');
 var path = require('path');
-
 var tilelive = require('tilelive');
 var Vector = require('tilelive-vector');
 var MBTiles = require('mbtiles');
@@ -22,38 +21,16 @@ Vector.mapnik.register_fonts(path.dirname(require.resolve('mapbox-studio-pro-fon
 if (process.env.MapboxUploadValidateFonts)
   Vector.mapnik.register_fonts(process.env.MapboxUploadValidateFonts, { recurse: true });
 
-module.exports.filepath = function validateFilepath(filepath, callback) {
+module.exports = function(filepath,callback) {
   filepath = path.resolve(filepath);
   sniffer.quaff(filepath, true, function(err, protocol) {
     if (err) return callback(invalid(err));
-    callback(null, protocol);
-  });
-};
-
-module.exports.info = function validateInfo(uri, limits, callback) {
-  if (!callback) {
-    callback = limits;
-    limits = { max_metadata: 60 * 1024 };
-  }
-
-  tilelive.info(uri, function(err, info) {
-    if (err) return callback(invalid(err));
-    if (info.prepare) return callback(invalid('Source cannot contain prepare key'));
-
-    err = tilelive.verify(info);
-    if (err) return callback(invalid(err));
-
-    if (JSON.stringify(info).length > limits.max_metadata)
-      return callback(invalid('Metadata exceeds limit of %sk.', (limits.max_metadata / 1024).toFixed(1)));
-
-    callback(null, info);
-  });
-};
-
-module.exports.source = function validateSource(uri, callback) {
-  tilelive.load(uri, function(err, source) {
-    if (err) return callback(invalid(err));
-    callback(null, source);
+    var opts = {
+      "filepath": filepath,
+      "protocol": protocol,
+      "uri": protocol + '//' + filepath
+    };
+    module.exports[protocol.slice(0,-1)](opts, callback);
   });
 };
 

--- a/lib/validators/mbtiles.js
+++ b/lib/validators/mbtiles.js
@@ -2,21 +2,31 @@ var fs = require('fs');
 var tiletype = require('tiletype');
 var uploadLimits = require('mapbox-upload-limits');
 var invalid = require('../invalid');
+var util = require('./util');
 var queue = require('queue-async');
 var prettyBytes = require('pretty-bytes');
 
 module.exports = function validateMbtiles(opts, callback) {
   var limits = opts.limits || uploadLimits.mbtiles;
-
-  if (opts.info.formatter)
-    return callback(invalid('Use TileMill 0.7 or later to export MBTiles with a valid template.'));
-
-  queue()
-    .defer(validFormat, opts.source._db, opts.info)
-    .defer(deprecatedCarmen, opts.source._db)
-    .defer(fileSize, opts.filepath, limits)
-    .defer(dataCounts, opts.source._db, limits)
-    .await(callback);
+  util.info(opts.uri,function(err,info) {
+    if (err) {
+      return callback(err);
+    }
+    if (info.formatter) {
+      return callback(invalid('Use TileMill 0.7 or later to export MBTiles with a valid template.'));
+    }
+    util.source(opts.uri,function(err,source) {
+      if (err) {
+        return callback(err);
+      }
+      return queue()
+        .defer(validFormat, source._db, info)
+        .defer(deprecatedCarmen, source._db)
+        .defer(fileSize, opts.filepath, limits)
+        .defer(dataCounts, source._db, limits)
+        .await(callback);
+    });
+  });
 };
 
 function sqliteError(err) {

--- a/lib/validators/omnivore.js
+++ b/lib/validators/omnivore.js
@@ -2,6 +2,7 @@ var fs = require('fs');
 var uploadLimits = require('mapbox-upload-limits');
 var prettyBytes = require('pretty-bytes');
 var path = require('path');
+var util = require('./util');
 var queue = require('queue-async');
 var invalid = require('../invalid');
 var sniffer = require('mapbox-file-sniff');
@@ -51,7 +52,7 @@ module.exports = function validateOmnivore(opts, callback) {
         if (size > limits.max_filesize) {
           return callback(invalid('File is larger than ' + prettyBytes(limits.max_filesize) + '. Too big to process.'));
         }
-        callback();
+        util.info(opts.uri,callback);
       });
     });
   });

--- a/lib/validators/serialtiles.js
+++ b/lib/validators/serialtiles.js
@@ -43,6 +43,7 @@ function validateSerialtiles(opts, callback) {
       .pipe(validationStream)
       .once('error', fail)
       .on('finish', function(err) {
+          if (err) return callback(err);
           util.info(opts.uri,callback);
       }).resume();
   });

--- a/lib/validators/serialtiles.js
+++ b/lib/validators/serialtiles.js
@@ -2,6 +2,7 @@ var tilelive = require('tilelive');
 var uploadLimits = require('mapbox-upload-limits');
 var fs = require('fs');
 var zlib = require('zlib');
+var util = require('./util');
 var invalid = require('../invalid');
 var mapnik = require('mapnik');
 var tiletype = require('tiletype');
@@ -41,7 +42,9 @@ function validateSerialtiles(opts, callback) {
       .once('error', fail)
       .pipe(validationStream)
       .once('error', fail)
-      .on('finish', callback).resume();
+      .on('finish', function(err) {
+          util.info(opts.uri,callback);
+      }).resume();
   });
 }
 

--- a/lib/validators/tilejson.js
+++ b/lib/validators/tilejson.js
@@ -1,24 +1,28 @@
 var url = require('url');
 var invalid = require('../invalid');
+var util = require('./util');
 
 module.exports = validateTilejson;
 
 function validateTilejson(opts, callback) {
-  if (opts.info.tiles) {
-    for (var i = 0; i < opts.info.tiles.length; i++) {
-      if (!validHosts.test(url.parse(opts.info.tiles[i]).hostname))
-        return callback(invalid('Invalid hostname in TileJSON'));
-    }
-  }
+  util.info(opts.uri,function(err,info) {
+    if (err) return callback(err);
 
-  if (opts.info.grids) {
-    for (var j = 0; j < opts.info.grids.length; j++) {
-      if (!validHosts.test(url.parse(opts.info.grids[j]).hostname))
-        return callback(invalid('Invalid hostname in TileJSON'));
+    if (info.tiles) {
+      for (var i = 0; i < info.tiles.length; i++) {
+        if (!validHosts.test(url.parse(info.tiles[i]).hostname))
+          return callback(invalid('Invalid hostname in TileJSON'));
+      }
     }
-  }
 
-  callback();
+    if (info.grids) {
+      for (var j = 0; j < info.grids.length; j++) {
+        if (!validHosts.test(url.parse(info.grids[j]).hostname))
+          return callback(invalid('Invalid hostname in TileJSON'));
+      }
+    }
+    return callback();
+  });
 }
 
 var validHosts = validateTilejson.validHosts = /tilemill\.backend$|tiles\.mapbox\.com$|(^mapbox-(satellite|cloudless-testing|pixelmonster)|^tilestream-tilesets-production)\.s3\.amazonaws\.com$/;

--- a/lib/validators/tm2z.js
+++ b/lib/validators/tm2z.js
@@ -34,6 +34,6 @@ module.exports = function validateTm2z(opts, callback) {
           callback();
         });
       });
-    })
+    });
   });
 };

--- a/lib/validators/tm2z.js
+++ b/lib/validators/tm2z.js
@@ -2,6 +2,7 @@ var fs = require('fs');
 var invalid = require('../invalid');
 var uploadLimits = require('mapbox-upload-limits');
 var prettyBytes = require('pretty-bytes');
+var util = require('./util');
 
 module.exports = function validateTm2z(opts, callback) {
   var limits = opts.limits || uploadLimits.tm2z;
@@ -11,22 +12,28 @@ module.exports = function validateTm2z(opts, callback) {
     if (stat.size > limits.max_filesize) {
       return callback(invalid('File is larger than ' + prettyBytes(limits.max_filesize) + '. Too big to process.'));
     }
-    if (JSON.stringify(opts.info).length > limits.max_metadata) {
-      return callback(invalid('Metadata exceeds limit of %sk.', (limits.max_metadata / 1024).toFixed(1)));
-    }
+    util.info(opts.uri,function(err,info) {
+      if (err) return callback(err);
+      if (JSON.stringify(info).length > limits.max_metadata) {
+        return callback(invalid('Metadata exceeds limit of %sk.', (limits.max_metadata / 1024).toFixed(1)));
+      }
 
-    opts.source.profile(function(err, stats) {
-      if (err && err.code === 'EMAPNIK') return callback(invalid('Invalid style'));
+      util.source(opts.uri,function(err,source) {
+        if (err) return callback(err);
+        source.profile(function(err, stats) {
+          if (err && err.code === 'EMAPNIK') return callback(invalid('Invalid style'));
 
-      if (stats.drawtime.max > limits.max_drawtime)
-        return callback(invalid('At least one tile exceeds the draw time limit of %sms. Please optimize your styles.', limits.max_drawtime));
-      if (stats.drawtime.avg > limits.avg_drawtime)
-        return callback(invalid('The average tile draw time exceeds the limit of %sms. Please optimize your styles.', limits.avg_drawtime));
-      if (stats.imgbytes.max > limits.max_imgbytes)
-        return callback(invalid('At least one rendered tile exceeds the file size limit of %sk. Try lowering the number of PNG colors or JPEG quality in your project settings.', (limits.max_imgbytes / 1024).toFixed(1)));
-      if (stats.imgbytes.avg > limits.avg_imgbytes)
-        return callback(invalid('The average rendered tile exceeds the file size limit of %sk. Try lowering the number of PNG colors or JPEG quality in your project settings.', (limits.avg_imgbytes / 1024).toFixed(1)));
-      callback();
-    });
+          if (stats.drawtime.max > limits.max_drawtime)
+            return callback(invalid('At least one tile exceeds the draw time limit of %sms. Please optimize your styles.', limits.max_drawtime));
+          if (stats.drawtime.avg > limits.avg_drawtime)
+            return callback(invalid('The average tile draw time exceeds the limit of %sms. Please optimize your styles.', limits.avg_drawtime));
+          if (stats.imgbytes.max > limits.max_imgbytes)
+            return callback(invalid('At least one rendered tile exceeds the file size limit of %sk. Try lowering the number of PNG colors or JPEG quality in your project settings.', (limits.max_imgbytes / 1024).toFixed(1)));
+          if (stats.imgbytes.avg > limits.avg_imgbytes)
+            return callback(invalid('The average rendered tile exceeds the file size limit of %sk. Try lowering the number of PNG colors or JPEG quality in your project settings.', (limits.avg_imgbytes / 1024).toFixed(1)));
+          callback();
+        });
+      });
+    })
   });
 };

--- a/lib/validators/util.js
+++ b/lib/validators/util.js
@@ -1,0 +1,30 @@
+var tilelive = require('tilelive');
+var invalid = require('../invalid');
+
+module.exports.info = function validateInfo(uri, limits, callback) {
+  if (!callback) {
+    callback = limits;
+    limits = { max_metadata: 60 * 1024 };
+  }
+
+  tilelive.info(uri, function(err, info) {
+    if (err) return callback(invalid(err));
+    if (info.prepare) return callback(invalid('Source cannot contain prepare key'));
+
+    err = tilelive.verify(info);
+    if (err) return callback(invalid(err));
+
+    if (JSON.stringify(info).length > limits.max_metadata)
+      return callback(invalid('Metadata exceeds limit of %sk.', (limits.max_metadata / 1024).toFixed(1)));
+
+    callback(null, info);
+  });
+};
+
+module.exports.source = function validateSource(uri, callback) {
+  tilelive.load(uri, function(err, source) {
+    if (err) return callback(invalid(err));
+    callback(null, source);
+  });
+};
+

--- a/test/validate.test.js
+++ b/test/validate.test.js
@@ -1,25 +1,8 @@
 var test = require('tape').test;
 var validate = require('../lib/validate');
 var fixtures = require('./fixtures');
-//var expected = require('./expected');
-var queue = require('queue-async');
-//var testUtils = require('./util');
 
 process.env.MapboxAPIMaps = 'https://api.tiles.mapbox.com';
-
-var validFiletypes = Object.keys(fixtures.valid);
-var validProtocols = validFiletypes.map(function(k) {
-  if (k.indexOf('mbtiles') === 0) return 'mbtiles:';
-  if (k === 'csv') return 'omnivore:';
-  if (k === 'shp') return 'omnivore:';
-  if (k === 'tif') return 'omnivore:';
-  if (k === 'geojson') return 'omnivore:';
-  if (k === 'kml') return 'omnivore:';
-  if (k === 'gpx') return 'omnivore:';
-  if (k === 'tilejson') return 'tilejson:';
-  if (k === 'tm2z') return 'tm2z:';
-  if (k.indexOf('serialtiles') === 0) return 'serialtiles:';
-});
 
 test('lib.validate.filepath: unsupported file', function(t) {
   validate(fixtures.invalid.unsupported, function(err, protocol) {

--- a/test/validate.test.js
+++ b/test/validate.test.js
@@ -21,18 +21,6 @@ var validProtocols = validFiletypes.map(function(k) {
   if (k.indexOf('serialtiles') === 0) return 'serialtiles:';
 });
 
-test('lib.validate.filepath: valid', function(t) {
-  var q = queue();
-  validFiletypes.forEach(function(k) {
-    q.defer(validate, fixtures.valid[k]);
-  });
-  q.awaitAll(function(err, protocols) {
-    t.ifError(err, 'does not error on valid file types');
-    t.deepEqual(protocols, validProtocols, 'returned expected protocols');
-    t.end();
-  });
-});
-
 test('lib.validate.filepath: unsupported file', function(t) {
   validate(fixtures.invalid.unsupported, function(err, protocol) {
     t.ok(err, 'expected error');
@@ -41,84 +29,3 @@ test('lib.validate.filepath: unsupported file', function(t) {
     t.end();
   });
 });
-
-
-/*
-test('lib.validate.info: valid', function(t) {
-  var q = queue();
-  var expectedInfos = validFiletypes.map(function(k) {
-    return expected.info[k];
-  });
-  validFiletypes.forEach(function(k, i) {
-    q.defer(validate.info, validProtocols[i] + '//' + fixtures.valid[k]);
-  });
-  q.awaitAll(function(err, infos) {
-    t.ifError(err, 'does not error on valid files');
-    infos = infos.map(testUtils.infoTruncator);
-    t.deepEqual(infos, expectedInfos, 'expected info returned');
-    t.end();
-  });
-});
-
-test('lib.validate.info: unsupported file', function(t) {
-  validate('nonsense://' + fixtures.invalid.unsupported, function(err, info) {
-    t.ok(err, 'expected error');
-    t.equal(err.code, 'EINVALID', 'expected error code');
-    t.notOk(info, 'no info returned');
-    t.end();
-  });
-});
-
-test('lib.validate.info: invalid data in the file', function(t) {
-  validate('tilejson://' + fixtures.invalid.tilejson.bounds, function(err, info) {
-    t.ok(err, 'expected error');
-    t.equal(err.code, 'EINVALID', 'expected error code');
-    t.notOk(info, 'no info returned');
-    t.end();
-  });
-});
-
-test('lib.validate.info: invalid metadata size', function(t) {
-  validate('tilejson://' + fixtures.valid.tilejson, { max_metadata: 50 }, function(err) {
-    t.ok(err, 'expected error');
-    t.equal(err.code, 'EINVALID', 'expected error code');
-    t.equal(err.message, 'Metadata exceeds limit of 0.0k.', 'expected error message');
-    t.end();
-  });
-});
-
-test('lib.validate.source: valid', function(t) {
-  var q = queue();
-  validFiletypes.forEach(function(k, i) {
-    q.defer(validate.source, validProtocols[i] + '//' + fixtures.valid[k]);
-  });
-  q.awaitAll(function(err, sources) {
-    t.ifError(err, 'does not error on valid files');
-    var valid = sources.reduce(function(memo, source) {
-      if (typeof source.getInfo !== 'function') memo = false;
-      if (typeof source.getTile !== 'function') memo = false;
-      return memo;
-    }, true);
-    t.ok(valid, 'sources appear valid');
-    t.end();
-  });
-});
-
-test('lib.validate.source: unsupported file', function(t) {
-  validate('nonsense://' + fixtures.invalid.unsupported, function(err, source) {
-    t.ok(err, 'expected error');
-    t.equal(err.code, 'EINVALID', 'expected error code');
-    t.notOk(source, 'no source returned');
-    t.end();
-  });
-});
-
-test('lib.validate.source: invalid data in the file', function(t) {
-  validate('tilejson://' + fixtures.invalid.tilejson.bounds, function(err, source) {
-    t.ok(err, 'expected error');
-    t.equal(err.code, 'EINVALID', 'expected error code');
-    t.notOk(source, 'no source returned');
-    t.end();
-  });
-});
-*/

--- a/test/validate.test.js
+++ b/test/validate.test.js
@@ -1,9 +1,9 @@
 var test = require('tape').test;
 var validate = require('../lib/validate');
 var fixtures = require('./fixtures');
-var expected = require('./expected');
+//var expected = require('./expected');
 var queue = require('queue-async');
-var testUtils = require('./util');
+//var testUtils = require('./util');
 
 process.env.MapboxAPIMaps = 'https://api.tiles.mapbox.com';
 

--- a/test/validate.test.js
+++ b/test/validate.test.js
@@ -24,7 +24,7 @@ var validProtocols = validFiletypes.map(function(k) {
 test('lib.validate.filepath: valid', function(t) {
   var q = queue();
   validFiletypes.forEach(function(k) {
-    q.defer(validate.filepath, fixtures.valid[k]);
+    q.defer(validate, fixtures.valid[k]);
   });
   q.awaitAll(function(err, protocols) {
     t.ifError(err, 'does not error on valid file types');
@@ -34,7 +34,7 @@ test('lib.validate.filepath: valid', function(t) {
 });
 
 test('lib.validate.filepath: unsupported file', function(t) {
-  validate.filepath(fixtures.invalid.unsupported, function(err, protocol) {
+  validate(fixtures.invalid.unsupported, function(err, protocol) {
     t.ok(err, 'expected error');
     t.equal(err.code, 'EINVALID', 'expected error code');
     t.notOk(protocol, 'no protocol returned');
@@ -42,6 +42,8 @@ test('lib.validate.filepath: unsupported file', function(t) {
   });
 });
 
+
+/*
 test('lib.validate.info: valid', function(t) {
   var q = queue();
   var expectedInfos = validFiletypes.map(function(k) {
@@ -59,7 +61,7 @@ test('lib.validate.info: valid', function(t) {
 });
 
 test('lib.validate.info: unsupported file', function(t) {
-  validate.info('nonsense://' + fixtures.invalid.unsupported, function(err, info) {
+  validate('nonsense://' + fixtures.invalid.unsupported, function(err, info) {
     t.ok(err, 'expected error');
     t.equal(err.code, 'EINVALID', 'expected error code');
     t.notOk(info, 'no info returned');
@@ -68,7 +70,7 @@ test('lib.validate.info: unsupported file', function(t) {
 });
 
 test('lib.validate.info: invalid data in the file', function(t) {
-  validate.info('tilejson://' + fixtures.invalid.tilejson.bounds, function(err, info) {
+  validate('tilejson://' + fixtures.invalid.tilejson.bounds, function(err, info) {
     t.ok(err, 'expected error');
     t.equal(err.code, 'EINVALID', 'expected error code');
     t.notOk(info, 'no info returned');
@@ -77,7 +79,7 @@ test('lib.validate.info: invalid data in the file', function(t) {
 });
 
 test('lib.validate.info: invalid metadata size', function(t) {
-  validate.info('tilejson://' + fixtures.valid.tilejson, { max_metadata: 50 }, function(err) {
+  validate('tilejson://' + fixtures.valid.tilejson, { max_metadata: 50 }, function(err) {
     t.ok(err, 'expected error');
     t.equal(err.code, 'EINVALID', 'expected error code');
     t.equal(err.message, 'Metadata exceeds limit of 0.0k.', 'expected error message');
@@ -103,7 +105,7 @@ test('lib.validate.source: valid', function(t) {
 });
 
 test('lib.validate.source: unsupported file', function(t) {
-  validate.info('nonsense://' + fixtures.invalid.unsupported, function(err, source) {
+  validate('nonsense://' + fixtures.invalid.unsupported, function(err, source) {
     t.ok(err, 'expected error');
     t.equal(err.code, 'EINVALID', 'expected error code');
     t.notOk(source, 'no source returned');
@@ -112,10 +114,11 @@ test('lib.validate.source: unsupported file', function(t) {
 });
 
 test('lib.validate.source: invalid data in the file', function(t) {
-  validate.info('tilejson://' + fixtures.invalid.tilejson.bounds, function(err, source) {
+  validate('tilejson://' + fixtures.invalid.tilejson.bounds, function(err, source) {
     t.ok(err, 'expected error');
     t.equal(err.code, 'EINVALID', 'expected error code');
     t.notOk(source, 'no source returned');
     t.end();
   });
 });
+*/

--- a/test/validators.mbtiles.test.js
+++ b/test/validators.mbtiles.test.js
@@ -22,7 +22,8 @@ function validate(filepath, limits, callback) {
         filepath: filepath,
         protocol: 'mbtiles:',
         info: info,
-        source: source
+        source: source,
+        uri: 'mbtiles://' + filepath
       };
       if (limits) opts.limits = limits;
       mbtiles(opts, callback);

--- a/test/validators.omnivore.test.js
+++ b/test/validators.omnivore.test.js
@@ -22,7 +22,8 @@ function validate(filepath, maxSize, callback) {
       filepath: filepath,
       protocol: 'omnivore:',
       info: expected.info.tilejson,
-      source: source
+      source: source,
+      uri: 'omnivore://' + filepath
     };
     if (maxSize) opts.limits = { max_filesize: maxSize };
     omnivore(opts, callback);

--- a/test/validators.serialtiles.test.js
+++ b/test/validators.serialtiles.test.js
@@ -19,7 +19,8 @@ function validate(filepath, limits, callback) {
       filepath: filepath,
       protocol: 'serialtiles:',
       info: expected.info.tilejson,
-      source: source
+      source: source,
+      uri: 'serialtiles://' + filepath
     };
 
     if (limits) opts.limits = limits;

--- a/test/validators.tilejson.test.js
+++ b/test/validators.tilejson.test.js
@@ -20,7 +20,8 @@ function validate(filepath, limits, callback) {
       filepath: filepath,
       protocol: 'tilejson:',
       info: expected.info.tilejson,
-      source: source
+      source: source,
+      uri: 'tilejson://' + filepath
     };
     if (limits) opts.limits = limits;
 

--- a/test/validators.tm2z.test.js
+++ b/test/validators.tm2z.test.js
@@ -19,7 +19,8 @@ function validate(filepath, limits, callback) {
       filepath: filepath,
       protocol: 'tm2z:',
       info: expected.info.tm2z,
-      source: source
+      source: source,
+      uri: 'tm2z://' + filepath
     };
     if (limits) opts.limits = limits;
 


### PR DESCRIPTION
As I was reviewing #68 I noticed that, overall:

  - The order of validation is currently the same for all filetypes
  - Not all filetypes need the same validation
  - Currently for some filetypes the validation is redundant or not in the optimal order

For `:omnivore` types in particular the problem exists that:

  - The `digest` function in `mapnik-omnivore` is called 3 times on one file
  - A `tilelive-bridge` source is created twice for one file
  - Even though the `digest` function in `mapnik-omnivore` calls `sniffer.quaff` internally we still call `sniffer.quaff` first before calling `digest` [here](https://github.com/mapbox/mapbox-upload-validate/blob/4e5b7482f3706b810c9e570b0a1c5a0f7277a17c/lib/validators/omnivore.js#L20)

If any one of these functions is expensive (they are for big files) then the cost compounds.

This PR starts refactoring the code so that validation does not try to be generic for all filetypes. Rather we call into the filetype specific validator and inside each we can optimize the order and necessary calls. In particular this fixes the case that breaks in #68 so that the existing KML layer count validation is able to run before `tilelive.info` which would never finish because it is so expensive.

/cc @mapsam @who8mycakes 