### PR TITLE
Bump to 4.0.0, mapnik to 3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.13.0
+
+* Update tilelive-omnivore@3.6.0
+* Update mapnik-omnivore@8.6.0
+* Update tilelive-vector@3.11.0
+* Update mapnik to 3.7.0
+
 ## 3.12.0
 
 * Update tilelive-omnivore@3.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
-## 3.13.0
+## 4.0.0
 
-* Update tilelive-omnivore@3.6.0
-* Update mapnik-omnivore@8.6.0
-* Update tilelive-vector@3.11.0
+* Update tilelive-omnivore@4.0.0
+* Update mapnik-omnivore@9.0.0
+* Update tilelive-vector@4.0.0
 * Update mapnik to 3.7.0
+* Drops window support
 
 ## 3.12.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-upload-validate",
-  "version": "3.12.0",
+  "version": "3.13.0",
   "description": "Validate that a file can be uploaded to Mapbox",
   "main": "index.js",
   "scripts": {
@@ -22,15 +22,15 @@
   },
   "homepage": "https://github.com/mapbox/mapbox-upload-validate",
   "dependencies": {
-    "@mapbox/mapnik-omnivore": "~8.5.0",
-    "@mapbox/tilelive-omnivore": "~3.5.0",
-    "@mapbox/tilelive-vector": "~3.10.0",
+    "@mapbox/mapnik-omnivore": "~8.6.0",
+    "@mapbox/tilelive-omnivore": "~3.6.0",
+    "@mapbox/tilelive-vector": "~3.11.0",
     "@mapbox/mapbox-file-sniff": "~1.0.0",
     "gdal": "~0.9.3",
     "mapbox-studio-default-fonts": "https://mapbox-npm.s3.amazonaws.com/package/mapbox-studio-default-fonts-0.0.4-4afb5235f457bd1c1a5a70fce6c2aa83bf7a851e.tgz",
     "mapbox-studio-pro-fonts": "https://mapbox-npm.s3.amazonaws.com/package/mapbox-studio-pro-fonts-1.0.0-9870a90b713f307b9391829602f4d5857e419615.tgz",
     "mapbox-upload-limits": "^1.2.0",
-    "mapnik": "~3.6.0",
+    "mapnik": "~3.7.0",
     "@mapbox/mbtiles": "~0.9.0",
     "pretty-bytes": "^3.0.0",
     "queue-async": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-upload-validate",
-  "version": "3.13.0",
+  "version": "4.0.0",
   "description": "Validate that a file can be uploaded to Mapbox",
   "main": "index.js",
   "scripts": {
@@ -22,9 +22,9 @@
   },
   "homepage": "https://github.com/mapbox/mapbox-upload-validate",
   "dependencies": {
-    "@mapbox/mapnik-omnivore": "~8.6.0",
-    "@mapbox/tilelive-omnivore": "~3.6.0",
-    "@mapbox/tilelive-vector": "~3.11.0",
+    "@mapbox/mapnik-omnivore": "~9.0.0",
+    "@mapbox/tilelive-omnivore": "~4.0.0",
+    "@mapbox/tilelive-vector": "~4.0.0",
     "@mapbox/mapbox-file-sniff": "~1.0.0",
     "gdal": "~0.9.3",
     "mapbox-studio-default-fonts": "https://mapbox-npm.s3.amazonaws.com/package/mapbox-studio-default-fonts-0.0.4-4afb5235f457bd1c1a5a70fce6c2aa83bf7a851e.tgz",


### PR DESCRIPTION
Update to version `4.0.0`, mapnik to `3.7.0` drops windows support