### PR TITLE
Allow limits to be set by environment variable

### DIFF
--- a/lib/validators/mbtiles.js
+++ b/lib/validators/mbtiles.js
@@ -4,9 +4,12 @@ var uploadLimits = require('mapbox-upload-limits');
 var invalid = require('../invalid');
 var queue = require('queue-async');
 var prettyBytes = require('pretty-bytes');
+if (process.env.CUSTOM_MBTILES_LIMITS) {
+  var customLimits = require(process.env.CUSTOM_MBTILES_LIMITS);
+}
 
 module.exports = function validateMbtiles(opts, callback) {
-  var limits = process.env.MBTILES_MAX_SIZE ? process.env.MBTILES_MAX_SIZE : opts.limits || uploadLimits.mbtiles;
+  var limits = customLimits ? customLimits : opts.limits || uploadLimits.mbtiles;
 
   if (opts.info.formatter)
     return callback(invalid('Use TileMill 0.7 or later to export MBTiles with a valid template.'));
@@ -38,7 +41,7 @@ function validFormat(db, info, callback) {
     err = sqliteError(err);
     if (err) return callback(err);
 
-    if (!result) return callback(); // no-op for no tiles 
+    if (!result) return callback(); // no-op for no tiles
     if (!result.tile_data) return callback(invalid('Tile is invalid'));
 
     var format = tiletype.type(result.tile_data);

--- a/lib/validators/mbtiles.js
+++ b/lib/validators/mbtiles.js
@@ -6,7 +6,7 @@ var queue = require('queue-async');
 var prettyBytes = require('pretty-bytes');
 
 module.exports = function validateMbtiles(opts, callback) {
-  var limits = opts.limits || uploadLimits.mbtiles;
+  var limits = process.env.MBTILES_MAX_SIZE ? process.env.MBTILES_MAX_SIZE : opts.limits || uploadLimits.mbtiles;
 
   if (opts.info.formatter)
     return callback(invalid('Use TileMill 0.7 or later to export MBTiles with a valid template.'));

--- a/test/fixtures/custom-mbtiles-limits.json
+++ b/test/fixtures/custom-mbtiles-limits.json
@@ -1,0 +1,6 @@
+{
+    "max_filesize": 2,
+    "max_tilesize": 3,
+    "max_gridsize": 4,
+    "max_totalitems": 5
+}


### PR DESCRIPTION
Lets limits be defined by environment variable `MBTILES_MAX_SIZE` if set for non-cloud uploads.

