### PR TITLE
Bump mapbox-upload-limits to v1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-upload-validate",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "Validate that a file can be uploaded to Mapbox",
   "main": "index.js",
   "scripts": {
@@ -22,23 +22,23 @@
   },
   "homepage": "https://github.com/mapbox/mapbox-upload-validate",
   "dependencies": {
+    "@mapbox/mapbox-file-sniff": "~1.0.0",
     "@mapbox/mapnik-omnivore": "~9.0.0",
+    "@mapbox/mbtiles": "~0.9.0",
+    "@mapbox/tilejson": "^1.0.3",
+    "@mapbox/tilelive": "~5.12.0",
     "@mapbox/tilelive-omnivore": "~4.1.0",
     "@mapbox/tilelive-vector": "~4.0.0",
-    "@mapbox/mapbox-file-sniff": "~1.0.0",
+    "@mapbox/tiletype": "~0.3.0",
     "gdal": "~0.9.3",
     "mapbox-studio-default-fonts": "https://mapbox-npm.s3.amazonaws.com/package/mapbox-studio-default-fonts-0.0.4-4afb5235f457bd1c1a5a70fce6c2aa83bf7a851e.tgz",
     "mapbox-studio-pro-fonts": "https://mapbox-npm.s3.amazonaws.com/package/mapbox-studio-pro-fonts-1.0.0-9870a90b713f307b9391829602f4d5857e419615.tgz",
-    "mapbox-upload-limits": "^1.2.0",
+    "mapbox-upload-limits": "^1.3.0",
     "mapnik": "~3.7.0",
-    "@mapbox/mbtiles": "~0.9.0",
     "pretty-bytes": "^3.0.0",
     "queue-async": "^1.0.7",
     "split": "~1.0.0",
     "step": "~0.0.6",
-    "@mapbox/tilejson": "^1.0.3",
-    "@mapbox/tilelive": "~5.12.0",
-    "@mapbox/tiletype": "~0.3.0",
     "underscore": "^1.7.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Pending a release of https://github.com/mapbox/mapbox-upload-limits/pull/9, which includes a 3x increase in tif `max_filesize`.